### PR TITLE
Correcting bad quotes on the title. This may fix the RSS feed issue

### DIFF
--- a/_posts/2024-11-05-t-sql-tuesday-180-good-enough-is-perfect.md
+++ b/_posts/2024-11-05-t-sql-tuesday-180-good-enough-is-perfect.md
@@ -1,6 +1,6 @@
 ---
 id: 4676
-title: 'T-SQL Tuesday #180 - Good Enough is Perfect
+title: 'T-SQL Tuesday #180 - Good Enough is Perfect'
 date: '2024-11-05T00:02:00+00:00'
 author: way0utwest
 layout: post


### PR DESCRIPTION
I think there's something wonky with the T-SQL Tuesday site RSS feed. It keeps popping #180, from November 2024, as the "latest" post with a current publication date (first screenshot). Right now it shows today as the publication date. That post doesn't appear further down in the XML between 179 and 181 (second screenshot).

Post 180 has an unclosed quote around the title in the frontmatter and I'm hoping that's what's causing it. This PR corrects the unclosed quote